### PR TITLE
[Feat] 내 트렌드함 UI 구현

### DIFF
--- a/app/(tabs)/my.js
+++ b/app/(tabs)/my.js
@@ -96,7 +96,10 @@ export default function My() {
             </View>
             <Text style={styles.menuText}>내 좋아요함</Text>
           </Pressable>
-          <View style={styles.menuItem}>
+          <Pressable
+            style={styles.menuItem}
+            onPress={() => router.push('/my-trends')}
+          >
             <View style={styles.squareBox}>
               <Svg
                 width="40"
@@ -135,8 +138,8 @@ export default function My() {
                 />
               </Svg>
             </View>
-            <Text style={styles.menuText}>내 키워드함</Text>
-          </View>
+            <Text style={styles.menuText}>내 트렌드함</Text>
+          </Pressable>
           <Pressable
             style={styles.menuItem}
             onPress={() => router.push('/my-posts')}

--- a/app/constants/my/DUMMY_TRENDS.js
+++ b/app/constants/my/DUMMY_TRENDS.js
@@ -1,0 +1,40 @@
+const DUMMY_TRENDS = [
+  {
+    date: '25.01.05',
+    items: [
+      { id: 1, title: 'FaSHioN', tag: '음악' },
+      { id: 2, title: '페이커', tag: '게임' },
+      { id: 3, title: '샤이니', tag: '음악' },
+      { id: 4, title: '토끼', tag: '반려동물' },
+      { id: 5, title: '고프코어', tag: '패션' },
+    ],
+  },
+  {
+    date: '25.01.04',
+    items: [
+      { id: 6, title: 'AOA 짧은 치마', tag: '음악' },
+      { id: 7, title: '졸업전시', tag: '일상/밈' },
+      { id: 8, title: '올영세일', tag: '뷰티' },
+      { id: 9, title: '겨울 패션 추천', tag: '패션' },
+      { id: 10, title: 'F1', tag: '스포츠' },
+    ],
+  },
+  {
+    date: '25.01.03',
+    items: [
+      { id: 11, title: '두바이쫀득쿠키', tag: '일상/밈' },
+      { id: 12, title: '슬릭백 챌린지', tag: '음악' },
+      { id: 13, title: '도쿄 브이로그', tag: '일상/밈' },
+    ],
+  },
+  {
+    date: '25.01.02',
+    items: [
+      { id: 14, title: '두바이쫀득쿠키', tag: '일상/밈' },
+      { id: 15, title: '슬릭백 챌린지', tag: '음악' },
+      { id: 16, title: '도쿄 브이로그', tag: '일상/밈' },
+    ],
+  },
+];
+
+export default DUMMY_TRENDS;

--- a/app/my-trends.js
+++ b/app/my-trends.js
@@ -1,0 +1,130 @@
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import TrendKeywordCard from './components/trend-keyword-card';
+import useThemedStyle from './hooks/use-themed-style';
+
+export default function MyTrends() {
+  const { styles } = useThemedStyle(getStyles);
+
+  const myTrendsDummyData = [
+    {
+      date: '25.01.05',
+      items: [
+        { id: 1, title: 'FaSHioN', tag: '음악' },
+        { id: 2, title: '페이커', tag: '게임' },
+        { id: 3, title: '샤이니', tag: '음악' },
+        { id: 4, title: '토끼', tag: '반려동물' },
+        { id: 5, title: '고프코어', tag: '패션' },
+      ],
+    },
+    {
+      date: '25.01.04',
+      items: [
+        { id: 6, title: 'AOA 짧은 치마', tag: '음악' },
+        { id: 7, title: '졸업전시', tag: '일상/밈' },
+        { id: 8, title: '올영세일', tag: '뷰티' },
+        { id: 9, title: '겨울 패션 추천', tag: '패션' },
+        { id: 10, title: 'F1', tag: '스포츠' },
+      ],
+    },
+    {
+      date: '25.01.03',
+      items: [
+        { id: 11, title: '두바이쫀득쿠키', tag: '일상/밈' },
+        { id: 12, title: '슬릭백 챌린지', tag: '음악' },
+        { id: 13, title: '도쿄 브이로그', tag: '일상/밈' },
+      ],
+    },
+    {
+      date: '25.01.02',
+      items: [
+        { id: 14, title: '두바이쫀득쿠키', tag: '일상/밈' },
+        { id: 15, title: '슬릭백 챌린지', tag: '음악' },
+        { id: 16, title: '도쿄 브이로그', tag: '일상/밈' },
+      ],
+    },
+  ];
+
+  return (
+    <SafeAreaView
+      style={styles.safeArea}
+      stickyHeader={[1]}
+      showsVerticalScrollIndicator={false}
+    >
+      <ScrollView
+        stickyHeaderIndices={[0]}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.headerContainer}>
+          <Text style={styles.headerText}>내 트렌드함</Text>
+        </View>
+        <View style={styles.trendsContainer}>
+          {myTrendsDummyData.map(group => (
+            <View key={group.date} style={styles.dayGroup}>
+              <Text style={styles.dateText}>{group.date}</Text>
+              <View style={styles.cardGroup}>
+                {group.items.map(item => (
+                  <TrendKeywordCard
+                    key={item.id}
+                    tag={item.tag}
+                    title={item.title}
+                    showTag={true}
+                  />
+                ))}
+              </View>
+            </View>
+          ))}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const getStyles = (isDark, primaryColors) => {
+  return StyleSheet.create({
+    safeArea: {
+      flex: 1,
+      backgroundColor: primaryColors.background,
+    },
+
+    headerContainer: {
+      paddingVertical: 10,
+      paddingLeft: 16,
+      paddingRight: 10,
+      backgroundColor: primaryColors.background,
+    },
+
+    headerText: {
+      fontSize: 20,
+      fontWeight: 700,
+      color: primaryColors.color,
+    },
+
+    trendsContainer: {
+      marginTop: 60,
+      marginLeft: 16,
+      marginRight: 30,
+      flexDirection: 'column',
+      gap: 40,
+    },
+
+    dayGroup: {
+      flexDirection: 'column',
+      gap: 24,
+    },
+
+    dateText: {
+      fontSize: 14,
+      fontWeight: 500,
+      height: 20,
+      lineHeight: 20,
+      color: primaryColors.color,
+    },
+
+    cardGroup: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      rowGap: 16,
+    },
+  });
+};

--- a/app/my-trends.js
+++ b/app/my-trends.js
@@ -8,11 +8,7 @@ export default function MyTrends() {
   const { styles } = useThemedStyle(getStyles);
 
   return (
-    <SafeAreaView
-      style={styles.safeArea}
-      stickyHeader={[1]}
-      showsVerticalScrollIndicator={false}
-    >
+    <SafeAreaView style={styles.safeArea}>
       <ScrollView
         stickyHeaderIndices={[0]}
         showsVerticalScrollIndicator={false}

--- a/app/my-trends.js
+++ b/app/my-trends.js
@@ -1,49 +1,11 @@
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import TrendKeywordCard from './components/trend-keyword-card';
+import DUMMY_TRENDS from './constants/my/DUMMY_TRENDS';
 import useThemedStyle from './hooks/use-themed-style';
 
 export default function MyTrends() {
   const { styles } = useThemedStyle(getStyles);
-
-  const myTrendsDummyData = [
-    {
-      date: '25.01.05',
-      items: [
-        { id: 1, title: 'FaSHioN', tag: '음악' },
-        { id: 2, title: '페이커', tag: '게임' },
-        { id: 3, title: '샤이니', tag: '음악' },
-        { id: 4, title: '토끼', tag: '반려동물' },
-        { id: 5, title: '고프코어', tag: '패션' },
-      ],
-    },
-    {
-      date: '25.01.04',
-      items: [
-        { id: 6, title: 'AOA 짧은 치마', tag: '음악' },
-        { id: 7, title: '졸업전시', tag: '일상/밈' },
-        { id: 8, title: '올영세일', tag: '뷰티' },
-        { id: 9, title: '겨울 패션 추천', tag: '패션' },
-        { id: 10, title: 'F1', tag: '스포츠' },
-      ],
-    },
-    {
-      date: '25.01.03',
-      items: [
-        { id: 11, title: '두바이쫀득쿠키', tag: '일상/밈' },
-        { id: 12, title: '슬릭백 챌린지', tag: '음악' },
-        { id: 13, title: '도쿄 브이로그', tag: '일상/밈' },
-      ],
-    },
-    {
-      date: '25.01.02',
-      items: [
-        { id: 14, title: '두바이쫀득쿠키', tag: '일상/밈' },
-        { id: 15, title: '슬릭백 챌린지', tag: '음악' },
-        { id: 16, title: '도쿄 브이로그', tag: '일상/밈' },
-      ],
-    },
-  ];
 
   return (
     <SafeAreaView
@@ -59,7 +21,7 @@ export default function MyTrends() {
           <Text style={styles.headerText}>내 트렌드함</Text>
         </View>
         <View style={styles.trendsContainer}>
-          {myTrendsDummyData.map(group => (
+          {DUMMY_TRENDS.map(group => (
             <View key={group.date} style={styles.dayGroup}>
               <Text style={styles.dateText}>{group.date}</Text>
               <View style={styles.cardGroup}>

--- a/assets/svgs/field_icon/sports_icon.js
+++ b/assets/svgs/field_icon/sports_icon.js
@@ -1,4 +1,4 @@
-import Svg, { Defs, G, Path, Rect } from 'react-native-svg';
+import Svg, { ClipPath, Defs, G, Path, Rect } from 'react-native-svg';
 
 export default function SportsIcon({ size, color }) {
   return (
@@ -16,9 +16,9 @@ export default function SportsIcon({ size, color }) {
         />
       </G>
       <Defs>
-        <clipPath id="clip0_1285_4616">
+        <ClipPath id="clip0_1285_4616">
           <Rect width="28" height="28" fill="white" />
-        </clipPath>
+        </ClipPath>
       </Defs>
     </Svg>
   );


### PR DESCRIPTION
### 📌 이슈번호

closes #37 

### ✅ PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔥 변경사항

내 트렌드함 UI 구현했습니다.
트렌드 키워드 컴포넌트에서 사용하는 SportsIcon에 clipPath 태그 문제가 있어서 간단하게 수정했습니다.

### 📷 테스트 결과
<img width="300" alt="Screenshot_1766166452" src="https://github.com/user-attachments/assets/c42ea2c0-d4fb-4cc1-840f-2e4681cc791c" />
<img width="300" alt="Screenshot_1766166421" src="https://github.com/user-attachments/assets/907ed310-94db-405e-982c-d3969d4f05a6" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * "내 트렌드함" 메뉴 항목이 상호작용 가능하도록 변경 — 선택 시 내 트렌드함 화면으로 이동
  * 내 트렌드함 화면 추가 — 날짜별로 정렬된 트렌드 그룹과 각 트렌드 항목을 한눈에 확인 가능

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->