### PR TITLE
[Feat] 내 댓글함 UI 구현

### DIFF
--- a/app/(tabs)/my.js
+++ b/app/(tabs)/my.js
@@ -170,7 +170,10 @@ export default function My() {
             </View>
             <Text style={styles.menuText}>내가 쓴 글</Text>
           </Pressable>
-          <View style={styles.menuItem}>
+          <Pressable
+            style={styles.menuItem}
+            onPress={() => router.push('/my-replys')}
+          >
             <View style={styles.squareBox}>
               <Svg
                 width="40"
@@ -186,7 +189,7 @@ export default function My() {
               </Svg>
             </View>
             <Text style={styles.menuText}>내 댓글함</Text>
-          </View>
+          </Pressable>
         </View>
 
         <View style={styles.editSection}>

--- a/app/components/my/FilterComponent.js
+++ b/app/components/my/FilterComponent.js
@@ -33,6 +33,7 @@ const getStyles = (isDark, primaryColors) => {
       position: 'relative',
       zIndex: 10,
     },
+
     container: {
       flexDirection: 'row',
       borderColor: color,
@@ -57,7 +58,7 @@ const getStyles = (isDark, primaryColors) => {
       left: 0,
       minWidth: 106,
       minHeight: 76,
-      backgroundColor: isDark ? '#323232' : '#D9D9D9',
+      backgroundColor: isDark ? '#454545' : '#D9D9D9',
       borderRadius: 10,
       elevation: 5,
     },

--- a/app/components/my/PostItem.js
+++ b/app/components/my/PostItem.js
@@ -4,14 +4,14 @@ import LikedIcon from '@/assets/svgs/my/like-icon';
 import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
 import DeleteComponent from './DeleteComponent';
 
-export default function PostItem({ post }) {
+export default function PostItem({ post, isMyReplys = false }) {
   const { isDark, styles, primaryColors } = useThemedStyle(getStyles);
 
   const hasImage = !!post.imageUrl;
 
   const textContent = (
     <>
-      {!hasImage && (
+      {(isMyReplys || !hasImage) && (
         <View style={styles.titleTextRow}>
           <Text style={styles.titleText} numberOfLines={1}>
             {post.title}
@@ -29,18 +29,20 @@ export default function PostItem({ post }) {
         <Text style={styles.detailText}># {post.category}</Text>
         <Text style={styles.detailText}>{post.timeAgo}</Text>
       </View>
-      <View style={styles.reactionRow}>
-        <LikedIcon color={primaryColors.color} />
-        <Text style={styles.reactionText}>{post.likeCount}</Text>
-        <CommentIcon color={primaryColors.color} />
-        <Text style={styles.reactionText}>{post.commentCount}</Text>
-      </View>
+      {!isMyReplys && (
+        <View style={styles.reactionRow}>
+          <LikedIcon color={primaryColors.color} />
+          <Text style={styles.reactionText}>{post.likeCount}</Text>
+          <CommentIcon color={primaryColors.color} />
+          <Text style={styles.reactionText}>{post.commentCount}</Text>
+        </View>
+      )}
     </>
   );
 
   return (
     <Pressable style={styles.container}>
-      {hasImage ? (
+      {hasImage && !isMyReplys ? (
         <View style={styles.contentWrapperCol}>
           <View style={styles.titleTextRow}>
             <Text style={styles.titleText} numberOfLines={1}>

--- a/app/my-replys.js
+++ b/app/my-replys.js
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import { FlatList, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import FilterComponent from './components/my/FilterComponent';
+import PostItem from './components/my/PostItem';
+import DUMMY_POSTS from './constants/my/DUMMY_POSTS';
+import useThemedStyle from './hooks/use-themed-style';
+
+export default function MyReplys() {
+  const { styles } = useThemedStyle(getStyles);
+
+  const renderPostItem = ({ item }) => {
+    return <PostItem post={item} isMyReplys={true} />;
+  };
+
+  const [openedFilter, setOpenedFilter] = useState(null);
+
+  const toggleFilter = filterName => {
+    setOpenedFilter(openedFilter === filterName ? null : filterName);
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <View style={styles.headerContainer}>
+        <Text style={styles.headerText}>내 댓글함</Text>
+      </View>
+      <View style={styles.filterContainer}>
+        <FilterComponent
+          text={'전체'}
+          isOpen={openedFilter === 'category'}
+          onPress={() => toggleFilter('category')}
+          options={['전체', '일반', '팁', '같이 촬영해요']}
+        />
+        <FilterComponent
+          text={'최신순'}
+          isOpen={openedFilter === 'sort'}
+          onPress={() => toggleFilter('sort')}
+          options={['최신순', '인기순', '과거순']}
+        />
+      </View>
+      <FlatList
+        style={styles.contentsListContainer}
+        data={DUMMY_POSTS}
+        renderItem={renderPostItem}
+        keyExtractor={item => item.id.toString()}
+      />
+    </SafeAreaView>
+  );
+}
+
+const getStyles = (isDark, primaryColors) => {
+  return StyleSheet.create({
+    safeArea: {
+      flex: 1,
+      backgroundColor: primaryColors.background,
+    },
+
+    headerContainer: {
+      paddingVertical: 10,
+      paddingLeft: 16,
+      paddingRight: 10,
+    },
+
+    headerText: {
+      fontSize: 20,
+      fontWeight: '700',
+      color: primaryColors.color,
+    },
+
+    filterContainer: {
+      marginTop: 16,
+      marginLeft: 19,
+      flexDirection: 'row',
+      gap: 16,
+      zIndex: 100,
+    },
+
+    contentsListContainer: {
+      marginTop: 16,
+      marginHorizontal: 18,
+    },
+  });
+};

--- a/app/my-replys.js
+++ b/app/my-replys.js
@@ -31,12 +31,6 @@ export default function MyReplys() {
           onPress={() => toggleFilter('category')}
           options={['전체', '일반', '팁', '같이 촬영해요']}
         />
-        <FilterComponent
-          text={'최신순'}
-          isOpen={openedFilter === 'sort'}
-          onPress={() => toggleFilter('sort')}
-          options={['최신순', '인기순', '과거순']}
-        />
       </View>
       <FlatList
         style={styles.contentsListContainer}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1534,6 +1534,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.7.0.tgz",
@@ -3615,6 +3628,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
@@ -3678,7 +3698,6 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -5635,7 +5654,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -11472,6 +11490,22 @@
         "prop-types": "^15.8.1"
       }
     },
+    "node_modules/react-native-gesture-handler": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.30.0.tgz",
+      "integrity": "sha512-5YsnKHGa0X9C8lb5oCnKm0fLUPM6CRduvUUw2Bav4RIj/C3HcFh4RIUnF8wgG6JQWCL1//gRx4v+LVWgcIQdGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-is-edge-to-edge": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz",
@@ -13426,7 +13460,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",


### PR DESCRIPTION
### 📌 이슈번호

closes #49 

### ✅ PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔥 변경사항

`PostItem` 수정 후 재사용하여 내 댓글함 UI 구현했습니다.

### 📷 테스트 결과

<img width="300" alt="Screenshot_1766820354" src="https://github.com/user-attachments/assets/db94bd83-968f-4f9a-8bee-d96468a88f30" />
<img width="300" alt="Screenshot_1766820372" src="https://github.com/user-attachments/assets/3b686c4d-05cb-4de7-a6bd-cecbe44075ef" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 내가 쓴 글 메뉴 항목이 내 댓글 페이지로 이동하는 버튼으로 변경
  * 내 댓글 화면 신규 추가 (카테고리 및 정렬 필터 포함)

* **개선 사항**
  * 내 댓글 표시 시 게시물 반응 인터페이스 비활성화
  * 내 댓글 페이지의 게시물 레이아웃 최적화 (텍스트 중심 표시)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->