### PR TITLE
[Feat] 댓글 / 답글 달기 API 연결 구현

### DIFF
--- a/app/(tabs)/feed/[id].js
+++ b/app/(tabs)/feed/[id].js
@@ -46,6 +46,7 @@ export default function FeedDetail() {
   const [replyTarget, setReplyTarget] = useState(null);
   const [isLiked, setIsLiked] = useState(false); // 로컬 상태
   const [likeCount, setLikeCount] = useState(0);
+  const [isSending, setIsSending] = useState(false);
 
   const fetchPost = useCallback(async () => {
     try {
@@ -149,11 +150,12 @@ export default function FeedDetail() {
   };
 
   const handleSendComment = async () => {
-    if (!commentText.trim()) return;
+    if (!commentText.trim() || isSending) return;
 
     try {
-      let finalContent = commentText;
+      setIsSending(true);
 
+      let finalContent = commentText;
       if (replyTarget) {
         const prefix = `@${replyTarget.name} `;
 
@@ -174,13 +176,15 @@ export default function FeedDetail() {
 
       const result = await createComment(id, commentData, accessToken);
 
-      if (result.success) {
+      if (result?.success) {
         Alert.alert('댓글이 등록되었습니다.');
         cancelReply();
         await fetchPost();
       }
     } catch (error) {
       Alert.alert('오류', error.message || '댓글 등록에 실패했습니다.');
+    } finally {
+      setIsSending(false);
     }
   };
 
@@ -378,7 +382,11 @@ export default function FeedDetail() {
             value={commentText}
             onChangeText={handleCommentChange}
           />
-          <Pressable onPress={handleSendComment}>
+          <Pressable
+            onPress={handleSendComment}
+            disabled={isSending}
+            style={{ opacity: isSending ? 0.5 : 1 }}
+          >
             <CommentSendIcon
               bgColor={primaryColors.pointColor}
               iconColor={primaryColors.iconPrimaryColor}

--- a/app/(tabs)/feed/[id].js
+++ b/app/(tabs)/feed/[id].js
@@ -65,18 +65,12 @@ export default function FeedDetail() {
   }, [id, accessToken, router]);
 
   useEffect(() => {
-    let isMounted = true;
-
     const init = async () => {
       setLoading(true);
       await fetchPost();
-      if (isMounted) setLoading(false);
+      setLoading(false);
     };
-
     init();
-    return () => {
-      isMounted = false;
-    };
   }, [fetchPost]);
 
   if (loading || !post) {

--- a/app/(tabs)/feed/[id].js
+++ b/app/(tabs)/feed/[id].js
@@ -51,10 +51,12 @@ export default function FeedDetail() {
   const fetchPost = useCallback(async () => {
     try {
       const data = await fetchPostDetail(id, accessToken);
-      if (data?.success) {
-        setPost(data.result);
-        setLikeCount(data.result.likeCount || 0);
+
+      if (!data?.success) {
+        throw new Error(data?.message || '데이터를 불러오지 못했습니다.');
       }
+      setPost(data.result);
+      setLikeCount(data.result.likeCount || 0);
     } catch (error) {
       Alert.alert('알림', error.message || '데이터를 불러오지 못했습니다.');
 

--- a/app/(tabs)/feed/[id].js
+++ b/app/(tabs)/feed/[id].js
@@ -152,7 +152,12 @@ export default function FeedDetail() {
   };
 
   const handleSendComment = async () => {
-    if (!commentText.trim() || isSending) return;
+    if (isSending) return;
+
+    if (!commentText.trim()) {
+      Alert.alert('알림', '댓글 내용을 입력해주세요.');
+      return;
+    }
 
     try {
       setIsSending(true);

--- a/app/(tabs)/feed/[id].js
+++ b/app/(tabs)/feed/[id].js
@@ -1,5 +1,10 @@
 import { AuthContext } from '@/app/_layout';
-import { fetchPostDetail, likeFeedPost, unlikeFeedPost } from '@/app/api/feed';
+import {
+  createComment,
+  fetchPostDetail,
+  likeFeedPost,
+  unlikeFeedPost,
+} from '@/app/api/feed';
 import CategoryBadge from '@/app/components/feed/CategoryBadge';
 import SearchBar from '@/app/components/feed/SearchBar';
 import { COMMUNITY_FIELDS } from '@/app/constants/common/COMMUNITY_FIELDS';
@@ -12,7 +17,7 @@ import BackIcon from '@/assets/svgs/feed/back-icon';
 import CommentSendIcon from '@/assets/svgs/feed/comment-send-icon';
 import ReplyArrowIcon from '@/assets/svgs/feed/reply-arrow-icon';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { Fragment, useContext, useEffect, useState } from 'react';
+import { Fragment, useCallback, useContext, useEffect, useState } from 'react';
 import {
   Alert,
   Image,
@@ -42,23 +47,37 @@ export default function FeedDetail() {
   const [isLiked, setIsLiked] = useState(false); // 로컬 상태
   const [likeCount, setLikeCount] = useState(0);
 
-  useEffect(() => {
-    const loadDetail = async () => {
-      try {
-        setLoading(true);
-        const data = await fetchPostDetail(id, accessToken);
-        if (data.success) {
-          setPost(data.result);
-          setLikeCount(data.result.likeCount || 0);
-        }
-      } catch (error) {
-        console.error('상세 조회 실패:', error);
-      } finally {
-        setLoading(false);
+  const fetchPost = useCallback(async () => {
+    try {
+      const data = await fetchPostDetail(id, accessToken);
+      if (data?.success) {
+        setPost(data.result);
+        setLikeCount(data.result.likeCount || 0);
       }
+    } catch (error) {
+      Alert.alert('알림', error.message || '데이터를 불러오지 못했습니다.');
+
+      setPost(prev => {
+        if (!prev) router.back();
+        return prev;
+      });
+    }
+  }, [id, accessToken, router]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const init = async () => {
+      setLoading(true);
+      await fetchPost();
+      if (isMounted) setLoading(false);
     };
-    loadDetail();
-  }, [id, accessToken]);
+
+    init();
+    return () => {
+      isMounted = false;
+    };
+  }, [fetchPost]);
 
   if (loading || !post) {
     return (
@@ -107,9 +126,68 @@ export default function FeedDetail() {
   const imageCount = post.imageUrls?.length || 0;
   const iconColor = isDark ? '#FAFAFA' : '#141414';
 
+  const cancelReply = () => {
+    setReplyTarget(null);
+    setCommentText('');
+  };
+
+  const handleCommentChange = input => {
+    if (replyTarget) {
+      const prefix = `@${replyTarget.name} `;
+
+      if (!input.startsWith(prefix)) {
+        setCommentText(prefix);
+      } else {
+        setCommentText(input);
+      }
+    } else {
+      setCommentText(input);
+    }
+  };
+
   const handleReplyPress = (commentId, authorName) => {
-    setReplyTarget({ id: commentId, name: authorName });
-    setCommentText(`@${authorName} `);
+    if (replyTarget?.id === commentId) {
+      cancelReply();
+    } else {
+      setReplyTarget({ id: commentId, name: authorName });
+      setCommentText(`@${authorName} `);
+    }
+  };
+
+  const handleSendComment = async () => {
+    if (!commentText.trim()) return;
+
+    try {
+      let finalContent = commentText;
+
+      if (replyTarget) {
+        const prefix = `@${replyTarget.name} `;
+
+        if (commentText.startsWith(prefix)) {
+          finalContent = commentText.slice(prefix.length);
+        }
+      }
+
+      if (!finalContent.trim()) {
+        Alert.alert('알림', '답글 내용을 입력해주세요.');
+        return;
+      }
+
+      const commentData = {
+        content: finalContent.trim(),
+        parentId: replyTarget ? replyTarget.id : null,
+      };
+
+      const result = await createComment(id, commentData, accessToken);
+
+      if (result.success) {
+        Alert.alert('댓글이 등록되었습니다.');
+        cancelReply();
+        await fetchPost();
+      }
+    } catch (error) {
+      Alert.alert('오류', error.message || '댓글 등록에 실패했습니다.');
+    }
   };
 
   return (
@@ -304,12 +382,14 @@ export default function FeedDetail() {
             placeholder="댓글을 입력하세요"
             placeholderTextColor={isDark ? '#454545' : '#F4F2F2'}
             value={commentText}
-            onChangeText={setCommentText}
+            onChangeText={handleCommentChange}
           />
-          <CommentSendIcon
-            bgColor={primaryColors.pointColor}
-            iconColor={primaryColors.iconPrimaryColor}
-          />
+          <Pressable onPress={handleSendComment}>
+            <CommentSendIcon
+              bgColor={primaryColors.pointColor}
+              iconColor={primaryColors.iconPrimaryColor}
+            />
+          </Pressable>
         </View>
       </View>
     </KeyboardAvoidingView>

--- a/app/api/feed.js
+++ b/app/api/feed.js
@@ -97,3 +97,16 @@ export const unlikeFeedPost = async (communityId, accessToken) => {
 
   return await parseJsonResponse(response);
 };
+
+export const createComment = async (communityId, commentData, accessToken) => {
+  const response = await fetch(`${API_BASE_URL}/comment/${communityId}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify(commentData),
+  });
+
+  return await parseJsonResponse(response);
+};

--- a/app/api/utils.js
+++ b/app/api/utils.js
@@ -8,7 +8,7 @@ export const parseJsonResponse = async response => {
     data = null;
   }
 
-  if (!response.ok) {
+  if (!response.ok || (data && data.success === false)) {
     const errorMsg =
       data?.message || data?.error || `서버 에러 (${response.status})`;
 


### PR DESCRIPTION
### 📌 이슈번호

#79 

### ✅ PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔥 변경사항

- 피드에 대해서 댓글 / 답글 달기 API 연결을 구현하였습니다.
- 원래 맨 처음 상세페이지 API 요청을 useEffect 안에서 구현하였던 부분을 `fetchPost()` 함수로 분리하여 댓글 작성 후에도 화면이 다시 로딩되도록 수정하였습니다.

*댓글 삭제와 게시글 삭제는 백엔드 상세페이지 수정 업데이트 반영 후에 구현 예정입니다.

### 📷 테스트 결과

ex) 결과물 스크린샷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 피드에 댓글 작성 기능 추가(전송/취소, 답글 모드 포함)
  * 댓글 입력 UI 및 전송 흐름 개선(전송 상태 표시, 입력 검증)

* **버그 수정**
  * 피드 불러오기 실패 시 사용자 알림 및 이전 화면 복귀 처리 개선
  * 페이지 언마운트 후 상태 업데이트 방지로 로딩 안정성 향상
  * 댓글 전송 및 API 실패 응답 감지·오류 처리 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->