### PR TITLE
[Feat] 내 좋아요함 조회 API 연결 구현

### DIFF
--- a/app/api/my.js
+++ b/app/api/my.js
@@ -30,6 +30,34 @@ export const fetchMyPosts = async (params, accessToken) => {
   return await parseJsonResponse(response);
 };
 
+export const fetchMyLikes = async (params, accessToken) => {
+  const { page = 0, size = 10, field, sort } = params;
+
+  const queryParams = new URLSearchParams({
+    page: page.toString(),
+    size: size.toString(),
+  });
+
+  if (field && field !== '전체') {
+    queryParams.append('field', field);
+  }
+
+  if (sort) {
+    queryParams.append('sort', sort);
+  }
+
+  const url = `${API_BASE_URL}/likes/me?${queryParams.toString()}`;
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  return await parseJsonResponse(response);
+};
+
 export const deletePost = async (communityId, accessToken) => {
   const url = `${API_BASE_URL}/community/${communityId}`;
 

--- a/app/components/my/PostItem.js
+++ b/app/components/my/PostItem.js
@@ -12,6 +12,7 @@ import DeleteComponent from './DeleteComponent';
 export default function PostItem({
   post,
   isMyReplys = false,
+  isLikePage = false,
   onDeleteSuccess,
 }) {
   const { isDark, styles, primaryColors } = useThemedStyle(getStyles);
@@ -58,6 +59,8 @@ export default function PostItem({
     );
   };
 
+  const showDeleteButton = !isLikePage && !isMyReplys;
+
   const textContent = (
     <>
       {(isMyReplys || !hasImage) && (
@@ -65,7 +68,9 @@ export default function PostItem({
           <Text style={styles.titleText} numberOfLines={1}>
             {post.title}
           </Text>
-          <DeleteComponent isDark={isDark} onDelete={handleDelete} />
+          {showDeleteButton && (
+            <DeleteComponent isDark={isDark} onDelete={handleDelete} />
+          )}
         </View>
       )}
       <Text style={styles.contentText} numberOfLines={2}>
@@ -94,7 +99,9 @@ export default function PostItem({
             <Text style={styles.titleText} numberOfLines={1}>
               {post.title}
             </Text>
-            <DeleteComponent isDark={isDark} onDelete={handleDelete} />
+            {showDeleteButton && (
+              <DeleteComponent isDark={isDark} onDelete={handleDelete} />
+            )}
           </View>
           <View style={styles.contentWrapperRow}>
             <View style={styles.contentWrapperCol}>{textContent}</View>

--- a/app/my-likes.js
+++ b/app/my-likes.js
@@ -115,8 +115,14 @@ export default function MyLikes() {
   };
 
   const onEndReached = () => {
-    if (!loading && hasNextPage && !onEndReachedDuringMomentum.current) {
-      loadPosts(page + 1);
+    if (
+      !loading &&
+      hasNextPage &&
+      !onEndReachedDuringMomentum.current &&
+      !isFetching.current
+    ) {
+      const nextPage = page + 1;
+      loadPosts(nextPage);
       onEndReachedDuringMomentum.current = true;
     }
   };

--- a/app/my-likes.js
+++ b/app/my-likes.js
@@ -1,19 +1,119 @@
-import { useState } from 'react';
-import { FlatList, StyleSheet, Text, View } from 'react-native';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { AuthContext } from './_layout';
+import { fetchMyLikes } from './api/my';
 import FilterComponent from './components/my/FilterComponent';
 import PostItem from './components/my/PostItem';
-import DUMMY_POSTS from './constants/my/DUMMY_POSTS';
+import {
+  COMMUNITY_FIELDS,
+  getCommunityFieldLabels,
+  getFieldKeyByLabel,
+} from './constants/common/COMMUNITY_FIELDS';
 import useThemedStyle from './hooks/use-themed-style';
 
 export default function MyLikes() {
   const { styles } = useThemedStyle(getStyles);
+  const { accessToken } = useContext(AuthContext);
 
-  const renderPostItem = ({ item }) => {
-    return <PostItem post={item} />;
+  const [posts, setPosts] = useState([]);
+  const [page, setPage] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [hasNextPage, setHasNextPage] = useState(true);
+
+  const [selectedField, setSelectedField] = useState('ALL');
+  const [selectedSort, setSelectedSort] = useState('latest');
+  const [openedFilter, setOpenedFilter] = useState(null);
+
+  const handleSelectFilter = label => {
+    const key = getFieldKeyByLabel(label);
+    if (key) {
+      setSelectedField(key);
+    }
+    setOpenedFilter(null);
   };
 
-  const [openedFilter, setOpenedFilter] = useState(null);
+  const isFetching = useRef(false);
+  const onEndReachedDuringMomentum = useRef(false);
+
+  const loadPosts = useCallback(
+    async (targetPage, isFresh = false) => {
+      if (isFetching.current) {
+        return;
+      }
+
+      if (!isFresh && targetPage === 0) {
+        return;
+      }
+
+      try {
+        isFetching.current = true;
+        setLoading(true);
+
+        const params = {
+          page: targetPage,
+          size: 10,
+          field: selectedField === 'ALL' ? null : selectedField,
+          sort: selectedSort,
+        };
+
+        const data = await fetchMyLikes(params, accessToken);
+
+        if (data?.success) {
+          const newPosts = data.result || [];
+
+          if (isFresh) {
+            setPosts(newPosts);
+            setPage(0);
+            setHasNextPage(newPosts.length === 10);
+          } else {
+            setPosts(prev => [...prev, ...newPosts]);
+            setPage(targetPage);
+            setHasNextPage(newPosts.length === 10);
+          }
+        }
+      } catch (e) {
+        console.error(e);
+      } finally {
+        isFetching.current = false;
+        setLoading(false);
+        setIsRefreshing(false);
+      }
+    },
+    [selectedField, selectedSort, accessToken],
+  );
+
+  useEffect(() => {
+    setPosts([]);
+    setPage(0);
+    setHasNextPage(true);
+    loadPosts(0, true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedField, selectedSort]);
+
+  const onRefresh = () => {
+    setIsRefreshing(true);
+    loadPosts(0, true);
+  };
+
+  const onEndReached = () => {
+    if (!loading && hasNextPage && !onEndReachedDuringMomentum.current) {
+      setPage(prev => {
+        const nextPage = prev + 1;
+        loadPosts(nextPage);
+        return nextPage;
+      });
+      onEndReachedDuringMomentum.current = true;
+    }
+  };
 
   const toggleFilter = filterName => {
     setOpenedFilter(openedFilter === filterName ? null : filterName);
@@ -22,27 +122,47 @@ export default function MyLikes() {
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.headerContainer}>
-        <Text style={styles.headerText}>내 좋아요함</Text>
+        <Text style={styles.headerText}>좋아요한 글</Text>
       </View>
+
       <View style={styles.filterContainer}>
         <FilterComponent
-          text={'전체'}
+          text={COMMUNITY_FIELDS[selectedField]}
           isOpen={openedFilter === 'category'}
           onPress={() => toggleFilter('category')}
-          options={['전체', '일반', '팁', '같이 촬영해요']}
+          options={getCommunityFieldLabels()}
+          onSelect={handleSelectFilter}
         />
+
         <FilterComponent
-          text={'최신순'}
+          text={selectedSort === 'latest' ? '최신순' : '인기순'}
           isOpen={openedFilter === 'sort'}
           onPress={() => toggleFilter('sort')}
-          options={['최신순', '인기순', '과거순']}
+          options={['최신순', '인기순']}
+          onSelect={val => {
+            setSelectedSort(val === '최신순' ? 'latest' : 'popular');
+            setOpenedFilter(null);
+          }}
         />
       </View>
+
       <FlatList
         style={styles.contentsListContainer}
-        data={DUMMY_POSTS}
-        renderItem={renderPostItem}
-        keyExtractor={item => item.id.toString()}
+        data={posts}
+        renderItem={({ item }) => <PostItem post={item} isLikePage={true} />}
+        keyExtractor={(item, index) => `like-${item.communityId}-${index}`}
+        onRefresh={onRefresh}
+        refreshing={isRefreshing}
+        onEndReached={onEndReached}
+        onEndReachedThreshold={0.2}
+        onMomentumScrollBegin={() => {
+          onEndReachedDuringMomentum.current = false;
+        }}
+        ListFooterComponent={
+          loading && !isRefreshing ? (
+            <ActivityIndicator style={{ margin: 20 }} />
+          ) : null
+        }
       />
     </SafeAreaView>
   );
@@ -54,19 +174,16 @@ const getStyles = (isDark, primaryColors) => {
       flex: 1,
       backgroundColor: primaryColors.background,
     },
-
     headerContainer: {
       paddingVertical: 10,
       paddingLeft: 16,
       paddingRight: 10,
     },
-
     headerText: {
       fontSize: 20,
       fontWeight: '700',
       color: primaryColors.color,
     },
-
     filterContainer: {
       marginTop: 16,
       marginLeft: 19,
@@ -74,7 +191,6 @@ const getStyles = (isDark, primaryColors) => {
       gap: 16,
       zIndex: 100,
     },
-
     contentsListContainer: {
       marginTop: 16,
       marginHorizontal: 18,

--- a/app/my-likes.js
+++ b/app/my-likes.js
@@ -43,16 +43,20 @@ export default function MyLikes() {
 
   const isFetching = useRef(false);
   const onEndReachedDuringMomentum = useRef(false);
+  const requestIdRef = useRef(0);
 
   const loadPosts = useCallback(
     async (targetPage, isFresh = false) => {
-      if (isFetching.current) {
+      // isFresh일 때는 진행 중이어도 허용 (필터 변경 시)
+      if (isFetching.current && !isFresh) {
         return;
       }
 
       if (!isFresh && targetPage === 0) {
         return;
       }
+
+      const requestId = ++requestIdRef.current;
 
       try {
         isFetching.current = true;
@@ -66,6 +70,9 @@ export default function MyLikes() {
         };
 
         const data = await fetchMyLikes(params, accessToken);
+
+        // 최신 요청이 아니면 무시
+        if (requestId !== requestIdRef.current) return;
 
         if (data?.success) {
           const newPosts = data.result || [];
@@ -83,9 +90,12 @@ export default function MyLikes() {
       } catch (e) {
         console.error(e);
       } finally {
-        isFetching.current = false;
-        setLoading(false);
-        setIsRefreshing(false);
+        // 최신 요청일 때만 로딩 상태 해제
+        if (requestId === requestIdRef.current) {
+          isFetching.current = false;
+          setLoading(false);
+          setIsRefreshing(false);
+        }
       }
     },
     [selectedField, selectedSort, accessToken],
@@ -106,11 +116,7 @@ export default function MyLikes() {
 
   const onEndReached = () => {
     if (!loading && hasNextPage && !onEndReachedDuringMomentum.current) {
-      setPage(prev => {
-        const nextPage = prev + 1;
-        loadPosts(nextPage);
-        return nextPage;
-      });
+      loadPosts(page + 1);
       onEndReachedDuringMomentum.current = true;
     }
   };


### PR DESCRIPTION
### 📌 이슈번호

#88 

### ✅ PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔥 변경사항

 내 좋아요함 조회 API 연결 구현하였습니다
카테고리별, 인기순 좋아요별 필터링 가능하도록 구현하였고, 10페이지씩 페이징되도록 구현하였습니다

### 📷 테스트 결과

ex) 결과물 스크린샷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 좋아요 목록 페이지에 동적 콘텐츠 로딩 및 페이지 매김 추가
  * 필터링 및 정렬 옵션 구현
  * 풀-투-리프레시 및 스크롤 시 자동 로드(무한 스크롤) 지원
  * 서버에서 좋아요 항목을 직접 불러오는 호출 추가 (인증 처리 포함)
* **Bug Fixes / UX**
  * 좋아요 페이지에서는 글 삭제 버튼이 표시되지 않도록 UI 개선
  * 로딩/새로고침 상태 표시 및 중복 요청 방지 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->