### PR TITLE
[Feat] 내 댓글함 조회 API 연결 구현

### DIFF
--- a/app/api/my.js
+++ b/app/api/my.js
@@ -58,6 +58,30 @@ export const fetchMyLikes = async (params, accessToken) => {
   return await parseJsonResponse(response);
 };
 
+export const fetchMyComments = async (params, accessToken) => {
+  const { page = 0, size = 10, field } = params;
+
+  const queryParams = new URLSearchParams({
+    page: page.toString(),
+    size: size.toString(),
+  });
+
+  if (field && field !== '전체') {
+    queryParams.append('field', field);
+  }
+
+  const url = `${API_BASE_URL}/comment/my?${queryParams.toString()}`;
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  return await parseJsonResponse(response);
+};
+
 export const deletePost = async (communityId, accessToken) => {
   const url = `${API_BASE_URL}/community/${communityId}`;
 

--- a/app/my-replys.js
+++ b/app/my-replys.js
@@ -1,19 +1,129 @@
-import { useState } from 'react';
-import { FlatList, StyleSheet, Text, View } from 'react-native';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { AuthContext } from './_layout';
+import { fetchMyComments } from './api/my';
 import FilterComponent from './components/my/FilterComponent';
 import PostItem from './components/my/PostItem';
-import DUMMY_POSTS from './constants/my/DUMMY_POSTS';
+import {
+  COMMUNITY_FIELDS,
+  getCommunityFieldLabels,
+  getFieldKeyByLabel,
+} from './constants/common/COMMUNITY_FIELDS';
 import useThemedStyle from './hooks/use-themed-style';
 
 export default function MyReplys() {
   const { styles } = useThemedStyle(getStyles);
+  const { accessToken } = useContext(AuthContext);
 
-  const renderPostItem = ({ item }) => {
-    return <PostItem post={item} isMyReplys={true} />;
+  const [posts, setPosts] = useState([]);
+  const [page, setPage] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [hasNextPage, setHasNextPage] = useState(true);
+
+  const [selectedField, setSelectedField] = useState('ALL');
+  const [openedFilter, setOpenedFilter] = useState(null);
+
+  const handleSelectFilter = label => {
+    const key = getFieldKeyByLabel(label);
+    if (key) {
+      setSelectedField(key);
+    }
+    setOpenedFilter(null);
   };
 
-  const [openedFilter, setOpenedFilter] = useState(null);
+  const isFetching = useRef(false);
+  const onEndReachedDuringMomentum = useRef(false);
+  const requestIdRef = useRef(0);
+
+  const loadPosts = useCallback(
+    async (targetPage, isFresh = false) => {
+      // isFresh일 때는 진행 중이어도 허용 (필터 변경 시)
+      if (isFetching.current && !isFresh) {
+        return;
+      }
+
+      if (!isFresh && targetPage === 0) {
+        return;
+      }
+
+      const requestId = ++requestIdRef.current;
+
+      try {
+        isFetching.current = true;
+        setLoading(true);
+
+        const params = {
+          page: targetPage,
+          size: 10,
+          field: selectedField === 'ALL' ? null : selectedField,
+        };
+
+        const data = await fetchMyComments(params, accessToken);
+
+        // 최신 요청이 아니면 무시
+        if (requestId !== requestIdRef.current) return;
+
+        if (data?.success) {
+          const newPosts = data.result || [];
+
+          if (isFresh) {
+            setPosts(newPosts);
+            setPage(0);
+            setHasNextPage(newPosts.length === 10);
+          } else {
+            setPosts(prev => [...prev, ...newPosts]);
+            setPage(targetPage);
+            setHasNextPage(newPosts.length === 10);
+          }
+        }
+      } catch (e) {
+        console.error(e);
+      } finally {
+        // 최신 요청일 때만 로딩 상태 해제
+        if (requestId === requestIdRef.current) {
+          isFetching.current = false;
+          setLoading(false);
+          setIsRefreshing(false);
+        }
+      }
+    },
+    [selectedField, accessToken],
+  );
+
+  useEffect(() => {
+    setPosts([]);
+    setPage(0);
+    setHasNextPage(true);
+    loadPosts(0, true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedField]);
+
+  const onRefresh = () => {
+    setIsRefreshing(true);
+    loadPosts(0, true);
+  };
+
+  const onEndReached = () => {
+    if (
+      !loading &&
+      hasNextPage &&
+      !onEndReachedDuringMomentum.current &&
+      !isFetching.current
+    ) {
+      const nextPage = page + 1;
+      loadPosts(nextPage);
+      onEndReachedDuringMomentum.current = true;
+    }
+  };
 
   const toggleFilter = filterName => {
     setOpenedFilter(openedFilter === filterName ? null : filterName);
@@ -24,19 +134,34 @@ export default function MyReplys() {
       <View style={styles.headerContainer}>
         <Text style={styles.headerText}>내 댓글함</Text>
       </View>
+
       <View style={styles.filterContainer}>
         <FilterComponent
-          text={'전체'}
+          text={COMMUNITY_FIELDS[selectedField]}
           isOpen={openedFilter === 'category'}
           onPress={() => toggleFilter('category')}
-          options={['전체', '일반', '팁', '같이 촬영해요']}
+          options={getCommunityFieldLabels()}
+          onSelect={handleSelectFilter}
         />
       </View>
+
       <FlatList
         style={styles.contentsListContainer}
-        data={DUMMY_POSTS}
-        renderItem={renderPostItem}
-        keyExtractor={item => item.id.toString()}
+        data={posts}
+        renderItem={({ item }) => <PostItem post={item} isMyReplys={true} />}
+        keyExtractor={(item, index) => `comment-${item.communityId}-${index}`}
+        onRefresh={onRefresh}
+        refreshing={isRefreshing}
+        onEndReached={onEndReached}
+        onEndReachedThreshold={0.2}
+        onMomentumScrollBegin={() => {
+          onEndReachedDuringMomentum.current = false;
+        }}
+        ListFooterComponent={
+          loading && !isRefreshing ? (
+            <ActivityIndicator style={{ margin: 20 }} />
+          ) : null
+        }
       />
     </SafeAreaView>
   );
@@ -48,19 +173,16 @@ const getStyles = (isDark, primaryColors) => {
       flex: 1,
       backgroundColor: primaryColors.background,
     },
-
     headerContainer: {
       paddingVertical: 10,
       paddingLeft: 16,
       paddingRight: 10,
     },
-
     headerText: {
       fontSize: 20,
       fontWeight: '700',
       color: primaryColors.color,
     },
-
     filterContainer: {
       marginTop: 16,
       marginLeft: 19,
@@ -68,7 +190,6 @@ const getStyles = (isDark, primaryColors) => {
       gap: 16,
       zIndex: 100,
     },
-
     contentsListContainer: {
       marginTop: 16,
       marginHorizontal: 18,


### PR DESCRIPTION
### 📌 이슈번호

#88 

### ✅ PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔥 변경사항

내 댓글함 리스트 조회 API 연결을 구현하였습니다.
내가 쓴 댓글의 게시물들을 조회할 수 있고 카테고리별로 필터링이 가능합니다.
내가 쓴 글, 내 좋아요함과 다르게 최신순 / 인기순 정렬 기능은 기획을 반영하여 제외하였습니다.

### 📷 테스트 결과

ex) 결과물 스크린샷
