### PR TITLE
[Feat] 피드 작성 s3 오류 수정 및 상세페이지 작성자 삭제 구현

### DIFF
--- a/app/api/feed.js
+++ b/app/api/feed.js
@@ -49,7 +49,7 @@ export const uploadFileToS3 = async (uploadUrl, uri, contentType) => {
   const response = await fetch(uri);
   const blob = await response.blob();
 
-  const uploadResponse = await fetch(uploadUrl, {
+  return await fetch(uploadUrl, {
     method: 'PUT',
     body: blob,
     headers: {
@@ -57,8 +57,6 @@ export const uploadFileToS3 = async (uploadUrl, uri, contentType) => {
       'x-amz-acl': 'public-read',
     },
   });
-
-  return await parseJsonResponse(uploadResponse);
 };
 
 export const createPost = async (postData, accessToken) => {

--- a/app/feed/[id].js
+++ b/app/feed/[id].js
@@ -5,13 +5,14 @@ import {
   likeFeedPost,
   unlikeFeedPost,
 } from '@/app/api/feed';
+import { deletePost } from '@/app/api/my';
 import CategoryBadge from '@/app/components/feed/CategoryBadge';
+import DeleteComponent from '@/app/components/my/DeleteComponent';
 import { COMMUNITY_FIELDS } from '@/app/constants/common/COMMUNITY_FIELDS';
 import { getPlatformLogo } from '@/app/constants/common/PLATFORM_LOGOS';
 import useThemedStyle from '@/app/hooks/use-themed-style';
 import CommentIcon from '@/assets/svgs/common/comment-icon';
 import LikedIcon from '@/assets/svgs/common/like-icon';
-import ThreeDotsIcon from '@/assets/svgs/common/three-dots-icon';
 import CommentSendIcon from '@/assets/svgs/feed/comment-send-icon';
 import ReplyArrowIcon from '@/assets/svgs/feed/reply-arrow-icon';
 import { useLocalSearchParams, useRouter } from 'expo-router';
@@ -90,6 +91,43 @@ export default function FeedDetail() {
       </View>
     );
   }
+
+  const handleDelete = () => {
+    Alert.alert(
+      '게시글 삭제',
+      '이 게시글을 삭제하시겠습니까?',
+      [
+        {
+          text: '취소',
+          style: 'cancel',
+        },
+        {
+          text: '삭제',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              const result = await deletePost(id, accessToken);
+
+              if (result.success) {
+                Alert.alert('성공', '게시글이 삭제되었습니다.', [
+                  {
+                    text: '확인',
+                    onPress: () => router.back(),
+                  },
+                ]);
+              } else {
+                Alert.alert('실패', '게시글 삭제에 실패했습니다.');
+              }
+            } catch (error) {
+              console.error('Delete error:', error);
+              Alert.alert('오류', '게시글 삭제 중 오류가 발생했습니다.');
+            }
+          },
+        },
+      ],
+      { cancelable: true },
+    );
+  };
 
   const handleLikePress = async () => {
     try {
@@ -196,7 +234,9 @@ export default function FeedDetail() {
           <View style={styles.postContainer}>
             <View style={styles.categoryRow}>
               <CategoryBadge text={COMMUNITY_FIELDS[post.field]} />
-              <ThreeDotsIcon isDark={isDark} />
+              {post.isWriter && (
+                <DeleteComponent isDark={isDark} onDelete={handleDelete} />
+              )}
             </View>
             <View style={styles.mainContentBox}>
               <View style={styles.authorProfileBox}>
@@ -229,13 +269,11 @@ export default function FeedDetail() {
               {imageCount > 0 && (
                 <View style={styles.imageSection}>
                   {imageCount === 1 ? (
-                    // 1장일 때: 가로로 꽉 찬 이미지
                     <Image
                       source={{ uri: post.imageUrls[0] }}
                       style={styles.singleImage}
                     />
                   ) : (
-                    // 2장 이상일 때: 273x273 정사각형 스크롤
                     <ScrollView
                       horizontal
                       showsHorizontalScrollIndicator={false}


### PR DESCRIPTION
### 📌 이슈번호

ex) #000

### ✅ PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔥 변경사항

피드 작성하며 s3 업로드 요청 후 응답값 처리시 json으로 받아오려고 했던 부분 수정
상세페이지에서 작성자인 경우 삭제 버튼 보이도록 하고, 삭제 가능하도록 구현

### 📷 테스트 결과

ex) 결과물 스크린샷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 게시물 삭제 기능 추가: 본인이 작성한 게시물에서 삭제 옵션을 표시합니다. 삭제 시 확인 프롬프트가 표시되며, 삭제 완료 후 피드로 이동합니다.

## 개선사항
* 게시물 헤더 UI 업데이트: 삭제 기능을 위한 새로운 UI 컴포넌트를 적용했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->