### PR TITLE
[Feat] 회원가입 시 프로필 이미지 추가

### DIFF
--- a/app/(sign-up)/step-context.js
+++ b/app/(sign-up)/step-context.js
@@ -113,7 +113,7 @@ export default function StepProvider({ children }) {
     return payload;
   }
 
-  const { kakaoEmail } = useContext(AuthContext);
+  const { kakaoEmail, kakaoProfileImageUrl } = useContext(AuthContext);
 
   const signUp = async () => {
     if (!kakaoEmail) {
@@ -128,6 +128,7 @@ export default function StepProvider({ children }) {
         birth: form.userInfo.birth,
         gender: form.userInfo.gender,
         userInterest: form.interests,
+        profileImageUrl: kakaoProfileImageUrl,
         ...buildChannelPayload(form.channelInfo),
       }),
     });

--- a/app/_layout.js
+++ b/app/_layout.js
@@ -11,6 +11,7 @@ export default function RootLayout() {
   const [accessToken, setAccessToken] = useState(null);
   const [refreshToken, setRefreshToken] = useState(null);
   const [kakaoEmail, setKakaoEmail] = useState(null);
+  const [kakaoProfileImageUrl, setKakaoProfileImageUrl] = useState(null);
 
   const { styles, isDark } = useThemedStyle(getStyles);
 
@@ -37,6 +38,8 @@ export default function RootLayout() {
         isLoggedIn: !!accessToken,
         kakaoEmail,
         setKakaoEmail,
+        kakaoProfileImageUrl,
+        setKakaoProfileImageUrl,
       }}
     >
       <Stack screenOptions={{ headerShown: false }} />

--- a/app/landing.js
+++ b/app/landing.js
@@ -15,8 +15,13 @@ export default function Landing() {
   const insets = useSafeAreaInsets();
   const { styles } = useThemedStyle(getStyles);
 
-  const { setAccessToken, setRefreshToken, setUser, setKakaoEmail } =
-    useContext(AuthContext);
+  const {
+    setAccessToken,
+    setRefreshToken,
+    setUser,
+    setKakaoEmail,
+    setKakaoProfileImageUrl,
+  } = useContext(AuthContext);
 
   useEffect(() => {
     initializeKakaoSDK('2d0e496c2a9ff2019280d0ff3d7ffb23');
@@ -67,6 +72,7 @@ export default function Landing() {
       if (result.newUser) {
         setUser(result.kakaoUserInfo);
         setKakaoEmail(result.kakaoUserInfo?.email ?? null);
+        setKakaoProfileImageUrl(result.kakaoUserInfo?.profileImage ?? null);
         router.replace('/(sign-up)');
         return;
       }
@@ -79,6 +85,7 @@ export default function Landing() {
       setRefreshToken(result.refreshToken);
       setUser(result.kakaoUserInfo);
       setKakaoEmail(result.kakaoUserInfo?.email ?? null);
+      setKakaoProfileImageUrl(result.kakaoUserInfo?.profileImage ?? null);
       router.replace('/(tabs)');
     } catch (error) {
       console.error('Kakao login failed', error);


### PR DESCRIPTION
### 📌 이슈번호

closes #95 

### ✅ PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔥 변경사항

- 회원가입 시 카카오톡 프로필 이미지를 함께 가져옵니다.

### 📷 테스트 결과

- 프로필 이미지 표시 확인
<img width="1080" height="578" alt="image" src="https://github.com/user-attachments/assets/2562dd17-6bd3-4e5e-ab70-0ebb929ea8a3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Kakao 로그인 시 사용자 프로필 이미지 URL을 자동으로 수집 및 저장하는 기능 추가
  * 신규 사용자 및 기존 사용자 모두의 가입 흐름에서 프로필 이미지 정보 처리 지원

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->