### PR TITLE
[Feat] 인증이 필요한 api fetch 구문을 authFetch로 변경

### DIFF
--- a/app/api/common.js
+++ b/app/api/common.js
@@ -1,3 +1,4 @@
+import { authFetch } from '@/lib/authFetch.js';
 import { parseJsonResponse } from './utils.js';
 
 const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL;
@@ -8,7 +9,7 @@ export const getPresignedUrl = async (fileName, contentType, token) => {
 
   const url = `${API_BASE_URL}/files/upload?fileName=${encodedFileName}&contentType=${encodedContentType}`;
 
-  const response = await fetch(url, {
+  const response = await authFetch(url, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,
@@ -20,10 +21,10 @@ export const getPresignedUrl = async (fileName, contentType, token) => {
 };
 
 export const uploadFileToS3 = async (uploadUrl, uri, contentType) => {
-  const response = await fetch(uri);
+  const response = await authFetch(uri);
   const blob = await response.blob();
 
-  return await fetch(uploadUrl, {
+  return await authFetch(uploadUrl, {
     method: 'PUT',
     body: blob,
     headers: {

--- a/app/api/common.js
+++ b/app/api/common.js
@@ -21,10 +21,10 @@ export const getPresignedUrl = async (fileName, contentType, token) => {
 };
 
 export const uploadFileToS3 = async (uploadUrl, uri, contentType) => {
-  const response = await authFetch(uri);
+  const response = await fetch(uri);
   const blob = await response.blob();
 
-  return await authFetch(uploadUrl, {
+  return await fetch(uploadUrl, {
     method: 'PUT',
     body: blob,
     headers: {

--- a/app/api/feed.js
+++ b/app/api/feed.js
@@ -1,3 +1,4 @@
+import { authFetch } from '@/lib/authFetch.js';
 import { parseJsonResponse } from './utils.js';
 
 const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL;
@@ -5,7 +6,7 @@ const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL;
 export const fetchCommunityPosts = async (field = 'RECOMMEND', accessToken) => {
   const url = `${API_BASE_URL}/community/filter?field=${field}`;
 
-  const response = await fetch(url, {
+  const response = await authFetch(url, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
@@ -17,7 +18,7 @@ export const fetchCommunityPosts = async (field = 'RECOMMEND', accessToken) => {
 };
 
 export const fetchPostDetail = async (communityId, accessToken) => {
-  const response = await fetch(`${API_BASE_URL}/community/${communityId}`, {
+  const response = await authFetch(`${API_BASE_URL}/community/${communityId}`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
@@ -34,7 +35,7 @@ export const getPresignedUrl = async (fileName, contentType, token) => {
 
   const url = `${API_BASE_URL}/files/upload?fileName=${encodedFileName}&contentType=${encodedContentType}`;
 
-  const response = await fetch(url, {
+  const response = await authFetch(url, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,
@@ -46,10 +47,10 @@ export const getPresignedUrl = async (fileName, contentType, token) => {
 };
 
 export const uploadFileToS3 = async (uploadUrl, uri, contentType) => {
-  const response = await fetch(uri);
+  const response = await authFetch(uri);
   const blob = await response.blob();
 
-  return await fetch(uploadUrl, {
+  return await authFetch(uploadUrl, {
     method: 'PUT',
     body: blob,
     headers: {
@@ -60,7 +61,7 @@ export const uploadFileToS3 = async (uploadUrl, uri, contentType) => {
 };
 
 export const createPost = async (postData, accessToken) => {
-  const response = await fetch(`${API_BASE_URL}/community/create`, {
+  const response = await authFetch(`${API_BASE_URL}/community/create`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -73,7 +74,7 @@ export const createPost = async (postData, accessToken) => {
 };
 
 export const likeFeedPost = async (communityId, accessToken) => {
-  const response = await fetch(`${API_BASE_URL}/likes/${communityId}`, {
+  const response = await authFetch(`${API_BASE_URL}/likes/${communityId}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -85,7 +86,7 @@ export const likeFeedPost = async (communityId, accessToken) => {
 };
 
 export const unlikeFeedPost = async (communityId, accessToken) => {
-  const response = await fetch(`${API_BASE_URL}/likes/${communityId}`, {
+  const response = await authFetch(`${API_BASE_URL}/likes/${communityId}`, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',
@@ -97,7 +98,7 @@ export const unlikeFeedPost = async (communityId, accessToken) => {
 };
 
 export const createComment = async (communityId, commentData, accessToken) => {
-  const response = await fetch(`${API_BASE_URL}/comment/${communityId}`, {
+  const response = await authFetch(`${API_BASE_URL}/comment/${communityId}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -128,7 +129,7 @@ export const searchCommunityPosts = async (params, accessToken) => {
 
   const url = `${API_BASE_URL}/community/search?${queryParams.toString()}`;
 
-  const response = await fetch(url, {
+  const response = await authFetch(url, {
     method: 'GET',
     headers: {
       Authorization: `Bearer ${accessToken}`,

--- a/app/api/feed.js
+++ b/app/api/feed.js
@@ -47,10 +47,10 @@ export const getPresignedUrl = async (fileName, contentType, token) => {
 };
 
 export const uploadFileToS3 = async (uploadUrl, uri, contentType) => {
-  const response = await authFetch(uri);
+  const response = await fetch(uri);
   const blob = await response.blob();
 
-  return await authFetch(uploadUrl, {
+  return await fetch(uploadUrl, {
     method: 'PUT',
     body: blob,
     headers: {

--- a/app/api/my.js
+++ b/app/api/my.js
@@ -1,3 +1,4 @@
+import { authFetch } from '@/lib/authFetch.js';
 import { parseJsonResponse } from './utils.js';
 
 const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL;
@@ -20,7 +21,7 @@ export const fetchMyPosts = async (params, accessToken) => {
 
   const url = `${API_BASE_URL}/community/my?${queryParams.toString()}`;
 
-  const response = await fetch(url, {
+  const response = await authFetch(url, {
     method: 'GET',
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -48,7 +49,7 @@ export const fetchMyLikes = async (params, accessToken) => {
 
   const url = `${API_BASE_URL}/likes/me?${queryParams.toString()}`;
 
-  const response = await fetch(url, {
+  const response = await authFetch(url, {
     method: 'GET',
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -72,7 +73,7 @@ export const fetchMyComments = async (params, accessToken) => {
 
   const url = `${API_BASE_URL}/comment/my?${queryParams.toString()}`;
 
-  const response = await fetch(url, {
+  const response = await authFetch(url, {
     method: 'GET',
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -85,7 +86,7 @@ export const fetchMyComments = async (params, accessToken) => {
 export const deletePost = async (communityId, accessToken) => {
   const url = `${API_BASE_URL}/community/${communityId}`;
 
-  const response = await fetch(url, {
+  const response = await authFetch(url, {
     method: 'DELETE',
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -98,7 +99,7 @@ export const deletePost = async (communityId, accessToken) => {
 export const fetchMe = async accessToken => {
   const url = `${API_BASE_URL}/user/me`;
 
-  const response = await fetch(url, {
+  const response = await authFetch(url, {
     method: 'GET',
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -112,7 +113,7 @@ export const fetchMe = async accessToken => {
 export const updateMe = async (channelData, accessToken) => {
   const url = `${API_BASE_URL}/user/update`;
 
-  const response = await fetch(url, {
+  const response = await authFetch(url, {
     method: 'PATCH',
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -127,7 +128,7 @@ export const updateMe = async (channelData, accessToken) => {
 export const deleteChannel = async (platform, accessToken) => {
   const url = `${API_BASE_URL}/user/update?platform=${platform.toUpperCase()}`;
 
-  const response = await fetch(url, {
+  const response = await authFetch(url, {
     method: 'DELETE',
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -141,7 +142,7 @@ export const deleteChannel = async (platform, accessToken) => {
 export const getMyInterest = async accessToken => {
   const url = `${API_BASE_URL}/user/interest`;
 
-  const response = await fetch(url, {
+  const response = await authFetch(url, {
     method: 'GET',
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -155,7 +156,7 @@ export const getMyInterest = async accessToken => {
 export const addInterest = async (category, accessToken) => {
   const url = `${API_BASE_URL}/user/interest/${encodeURIComponent(category)}`;
 
-  const response = await fetch(url, {
+  const response = await authFetch(url, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -169,7 +170,7 @@ export const addInterest = async (category, accessToken) => {
 export const deleteInterest = async (interestId, accessToken) => {
   const url = `${API_BASE_URL}/user/interest/${interestId}`;
 
-  const response = await fetch(url, {
+  const response = await authFetch(url, {
     method: 'DELETE',
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -183,7 +184,7 @@ export const deleteInterest = async (interestId, accessToken) => {
 export const deleteMe = async accessToken => {
   const url = `${API_BASE_URL}/user/me`;
 
-  const response = await fetch(url, {
+  const response = await authFetch(url, {
     method: 'DELETE',
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -196,7 +197,7 @@ export const deleteMe = async accessToken => {
 
 export const fetchMyTrends = async accessToken => {
   const url = `${API_BASE_URL}/main/trend/getUserTrend`;
-  const response = await fetch(url, {
+  const response = await authFetch(url, {
     method: 'GET',
     headers: {
       Authorization: `Bearer ${accessToken}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1541,19 +1541,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@egjs/hammerjs": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
-      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/hammerjs": "^2.0.36"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/@emnapi/core": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.7.0.tgz",
@@ -3775,20 +3762,6 @@
       "integrity": "sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g==",
       "license": "MIT"
     },
-    "node_modules/@react-native/virtualized-lists": {
-      "version": "0.72.8",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.72.8.tgz",
-      "integrity": "sha512-J3Q4Bkuo99k7mu+jPS9gSUSgq+lLRSI/+ahXNwV92XgJ/8UgOTxu2LPwhJnBk/sQKxq7E8WkZBnBiozukQMqrw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "invariant": "^2.2.4",
-        "nullthrows": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react-native": "*"
-      }
-    },
     "node_modules/@react-navigation/bottom-tabs": {
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.9.0.tgz",
@@ -4272,13 +4245,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/hammerjs": {
-      "version": "2.0.46",
-      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
-      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
@@ -4351,20 +4317,10 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/react-native": {
-      "version": "0.72.8",
-      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.72.8.tgz",
-      "integrity": "sha512-St6xA7+EoHN5mEYfdWnfYt0e8u6k2FR0P9s2arYgakQGFgU1f9FlPrIEcj0X24pLCF5c5i3WVuLCUdiCYHmOoA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@react-native/virtualized-lists": "^0.72.4",
-        "@types/react": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -12104,22 +12060,6 @@
         "prop-types": "^15.8.1"
       }
     },
-    "node_modules/react-native-gesture-handler": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.30.0.tgz",
-      "integrity": "sha512-5YsnKHGa0X9C8lb5oCnKm0fLUPM6CRduvUUw2Bav4RIj/C3HcFh4RIUnF8wgG6JQWCL1//gRx4v+LVWgcIQdGA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@egjs/hammerjs": "^2.0.17",
-        "hoist-non-react-statics": "^3.3.0",
-        "invariant": "^2.2.4"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/react-native-is-edge-to-edge": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz",
@@ -14089,7 +14029,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",


### PR DESCRIPTION
### 📌 이슈번호

closes #104 

### ✅ PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔥 변경사항

- 인증이 필요한 피드, 마이페이지 api의 fetch 구문을 authFetch로 변경하여 accessToken 만료 시 재발급 로직을 추가하였습니다.

### 📷 테스트 결과

.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 모든 API 호출에 대한 인증 처리 일관성이 개선되어 요청 시 권한 헤더가 안정적으로 적용됩니다.
  * 피드, 파일 업로드, 사용자 관련 API의 인증 안정성이 강화되어 권한 관련 오류 발생 가능성이 감소합니다.
  * 공개 API의 인터페이스(시그니처)는 변경되지 않았습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->